### PR TITLE
chore: rename dev database

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 # Make sure to override these in deployment
-DATABASE_URL="postgresql://postgres:@localhost:5432/trpc-starter-websockets?schema=public"
+DATABASE_URL="postgresql://postgres:@localhost:5432/electionsdata?schema=public"
 APP_URL="http://localhost:3000"
 WS_URL="ws://localhost:3001"
 NEXTAUTH_URL="http://localhost:3000/api/auth"


### PR DESCRIPTION
This renames the dev database specified in the currently included .env `DATABASE_URL` from `trpc-starter-websockets` to `electionsdata` so when the database is created locally it will be named `electionsdata`.

## Steps to test

1. Make sure you've got a local working Postgres database with a role named `postgres` which is set to not require a password.
2. `pnpm install`
3. `pnpm dev`
4. `psql -h localhost -U postgres electionsdata`
